### PR TITLE
Terminal-only Linux with Python2.6.6 support.

### DIFF
--- a/shellstream/config.py
+++ b/shellstream/config.py
@@ -30,4 +30,4 @@ class Config(object):
         streamer.token = options.token or os.getenv("SHELL_STREAM_TOKEN")
         streamer.title = options.title
         streamer.transport = HttpTransport()
-        streamer.output_dir = options.output_dir or "{}/streamshell/".format(tempfile.gettempdir())
+        streamer.output_dir = options.output_dir or "{0}/streamshell/".format(tempfile.gettempdir())

--- a/shellstream/shell.py
+++ b/shellstream/shell.py
@@ -62,18 +62,18 @@ class StreamingShell(object):
         try:
             self.transport.fetch("api/login/", {"encrypted_token": encrypted_token}, response_callback=self.transport.set_session_id)
         except TransportError, e:
-            print_red("\nFailed during login\n{}\n".format(e))
+            print_red("\nFailed during login\n{0}\n".format(e))
             sys.exit(1)
 
     def create_remote_stream(self):
         try:
             self.create_stream()
         except TransportError, e:
-            print_red("\nFailed to create stream:\n{}\n".format(e))
+            print_red("\nFailed to create stream:\n{0}\n".format(e))
             sys.exit(1)
         else:
-            stream_url = "http://www.enginehere.com/stream/{}/{}/".format(self.stream_id, self.stream_slug)
-            prompt(print_green, "\nAll of your commands within THIS SHELL will be piped to {}".format(stream_url))
+            stream_url = "http://www.enginehere.com/stream/{0}/{1}/".format(self.stream_id, self.stream_slug)
+            prompt(print_green, "\nAll of your commands within THIS SHELL will be piped to {0}".format(stream_url))
             webbrowser.open_new_tab(stream_url)
 
     def create_stream(self):
@@ -118,28 +118,28 @@ class StreamingShell(object):
 
     def _write_pid(self, path, pid):
         with open(path, "w") as f:
-            f.write("{}".format(pid))
+            f.write("{0}".format(pid))
         return self
 
     @property
     def _child_pid_path(self):
-        return "{}child_pid.{}.{}.{}.txt".format(self.output_dir, self.parent_pid, os.getpid(), self.timestamp)
+        return "{0}child_pid.{1}.{2}.{3}.txt".format(self.output_dir, self.parent_pid, os.getpid(), self.timestamp)
 
     @property
     def _parent_pid_path(self):
-        return "{}parent_pid.{}.{}.txt".format(self.output_dir, self.parent_pid, self.timestamp)
+        return "{0}parent_pid.{1}.{2}.txt".format(self.output_dir, self.parent_pid, self.timestamp)
 
     @property
     def _shell_output_path(self):
-        return "{}streaming_shell.{}.{}.txt".format(self.output_dir, self.parent_pid, self.timestamp)
+        return "{0}streaming_shell.{1}.{2}.txt".format(self.output_dir, self.parent_pid, self.timestamp)
 
     def _start_worker(self):
         Worker.labor(self.transport, self._shell_output_path, self.parent_pid, self.stream_id)
 
     def _start_recording(self):
         current_ps1 = os.environ.get("PS1", "\\w $\\[\\033[00m\\]")
-        bash_prompt_cmd = 'export PS1="{}{}"'.format(BASH_PROMPT, current_ps1)
-        cmd = "{};script -q -t 0 {}".format(bash_prompt_cmd, self._shell_output_path)
+        bash_prompt_cmd = 'export PS1="{0}{1}"'.format(BASH_PROMPT, current_ps1)
+        cmd = "{0};script -q -t 0 {1}".format(bash_prompt_cmd, self._shell_output_path)
         # This call blocks
         subprocess.call(cmd, shell=True)
 
@@ -163,7 +163,7 @@ class StreamingShell(object):
 
     def _clean_child_process(self):
         try:
-            child_pid_path = glob.glob("{}child_pid.{}.*".format(self.output_dir, self.parent_pid))[0]
+            child_pid_path = glob.glob("{0}child_pid.{1}.*".format(self.output_dir, self.parent_pid))[0]
             with open(child_pid_path, "r") as child_pid_file:
                 child_pid = child_pid_file.read()
 
@@ -173,11 +173,11 @@ class StreamingShell(object):
             logger.warning(e)
 
     def _init_local_stream_file(self):
-        subprocess.call("touch {}".format(self._shell_output_path), shell=True)
+        subprocess.call("touch {0}".format(self._shell_output_path), shell=True)
 
     def _display_intro(self):
         print
-        prompt(print_green, "Beginning StreamingShell mode [writing to {}]".format(self.output_dir))
+        prompt(print_green, "Beginning StreamingShell mode [writing to {0}]".format(self.output_dir))
         prompt(print_green, "To exit this mode, press the following keys")
         print_blue("\tctrl + d", ["bold", "underline"])
         print

--- a/shellstream/shell.py
+++ b/shellstream/shell.py
@@ -74,7 +74,8 @@ class StreamingShell(object):
         else:
             stream_url = "http://www.enginehere.com/stream/{0}/{1}/".format(self.stream_id, self.stream_slug)
             prompt(print_green, "\nAll of your commands within THIS SHELL will be piped to {0}".format(stream_url))
-            webbrowser.open_new_tab(stream_url)
+            # Commenting this out for now, since I'm using a terminal without any x windows.
+            # webbrowser.open_new_tab(stream_url)
 
     def create_stream(self):
         data = self.get_system_info()
@@ -102,15 +103,15 @@ class StreamingShell(object):
         data["python_executable"] = sys.executable
 
         try:
-            data["username"] = subprocess.check_output("id -u -n", shell=True)
-            user_id = subprocess.check_output("id -u", shell=True)
+            data["username"] = subprocess.Popen("id -n -u", shell=True, stdout=subprocess.PIPE).stdout.read().strip()
+            user_id = subprocess.Popen("id -u", shell=True, stdout=subprocess.PIPE).stdout.read().strip()
             if user_id:
                 data["user_id"] = int(user_id)
         except subprocess.CalledProcessError:
             pass
 
         try:
-            data["pip_installed_packages"] = subprocess.check_output("pip freeze", shell=True)
+            data["pip_installed_packages"] = subprocess.Popen("pip freeze", shell=True, stdout=subprocess.PIPE.stdout.read()
         except subprocess.CalledProcessError:
             data["pip_installed_packages"] = "Unknown: pip not installed"
 
@@ -139,7 +140,8 @@ class StreamingShell(object):
     def _start_recording(self):
         current_ps1 = os.environ.get("PS1", "\\w $\\[\\033[00m\\]")
         bash_prompt_cmd = 'export PS1="{0}{1}"'.format(BASH_PROMPT, current_ps1)
-        cmd = "{0};script -q -t 0 {1}".format(bash_prompt_cmd, self._shell_output_path)
+        # Be quite and flush output after each write.
+        cmd = "{0};script -q -f {1}".format(bash_prompt_cmd, self._shell_output_path)
         # This call blocks
         subprocess.call(cmd, shell=True)
 

--- a/shellstream/shell.py
+++ b/shellstream/shell.py
@@ -74,8 +74,9 @@ class StreamingShell(object):
         else:
             stream_url = "http://www.enginehere.com/stream/{0}/{1}/".format(self.stream_id, self.stream_slug)
             prompt(print_green, "\nAll of your commands within THIS SHELL will be piped to {0}".format(stream_url))
-            # Commenting this out for now, since I'm using a terminal without any x windows.
-            # webbrowser.open_new_tab(stream_url)
+            # Don't bother to open a terminal-based browser
+            if not webbrowser.get().name == 'lynx':
+                webbrowser.open_new_tab(stream_url)
 
     def create_stream(self):
         data = self.get_system_info()

--- a/shellstream/shell.py
+++ b/shellstream/shell.py
@@ -112,7 +112,7 @@ class StreamingShell(object):
             pass
 
         try:
-            data["pip_installed_packages"] = subprocess.Popen("pip freeze", shell=True, stdout=subprocess.PIPE.stdout.read()
+            data["pip_installed_packages"] = subprocess.Popen("pip freeze", shell=True, stdout=subprocess.PIPE).stdout.read()
         except subprocess.CalledProcessError:
             data["pip_installed_packages"] = "Unknown: pip not installed"
 

--- a/shellstream/transport.py
+++ b/shellstream/transport.py
@@ -17,7 +17,7 @@ class TransportError(Exception):
 class HttpTransport(RequestHelper):
 
     def get_endpoint(self, path):
-        return "{}{}".format(HOST, path)
+        return "{0}{1}".format(HOST, path)
 
     def parse_response(self, response):
         if response.ok:
@@ -32,7 +32,7 @@ class HttpTransport(RequestHelper):
                 else:
                     raise TransportError(res.get("errors"))
         else:
-            raise TransportError("Status Code {}:{}".format(response.status_code, response.content))
+            raise TransportError("Status Code {0}:{1}".format(response.status_code, response.content))
 
     def fetch(self, path, data=None, response_callback=None, method="post"):
         endpoint = self.get_endpoint(path)

--- a/shellstream/utils/io.py
+++ b/shellstream/utils/io.py
@@ -14,7 +14,7 @@ def wait_for_response(min_chars, prompt):
 
 
 def prompt(func, text):
-    func(">>>> {}".format(text))
+    func(">>>> {0}".format(text))
 
 
 def color_print(color, msg, attrs=None):
@@ -28,7 +28,7 @@ def init_printers():
 
     for color in ["red", "green", "yellow", "magenta", "blue", "grey", "cyan"]:
         f = partial(color_print, color)
-        fname = "print_{}".format(color)
+        fname = "print_{0}".format(color)
         if color not in mod.__dict__:  # Prevent overrides if run from an IDE.
             mod.__dict__[fname] = f
             mod.__dict__["__all__"].append(fname)

--- a/shellstream/worker.py
+++ b/shellstream/worker.py
@@ -134,7 +134,7 @@ class ShellReader(threading.Thread):
         # html = self.escape_html(html)
         html = self.remove_undos(html)
         _class = "bash-input" if BASH_PROMPT in html else "bash-output"
-        return '<pre class="{}">{}</pre>'.format(_class, html)
+        return '<pre class="{0}">{1}</pre>'.format(_class, html)
 
     def remove_undos(self, html):
         _buffer = []
@@ -146,7 +146,7 @@ class ShellReader(threading.Thread):
         return "".join(_buffer)
 
     def pad_input(self, html):
-        return '[div] class="shell-input"[--]{}[/div][div] class="shell-output[--][pre]'.format(html)
+        return '[div] class="shell-input"[--]{0}[/div][div] class="shell-output[--][pre]'.format(html)
 
     def close_padding(self):
         return '[/pre][/div]'
@@ -161,7 +161,7 @@ class ShellReader(threading.Thread):
             if object.group() == "</span>":
                 return "[/sp]"
             else:
-                return "[sp]{}[--]".format(object.group(1))
+                return "[sp]{0}[--]".format(object.group(1))
         return re.sub(self.span_regex, replace_it, html)
 
     def escape_pre(self, html):
@@ -170,7 +170,7 @@ class ShellReader(threading.Thread):
             if not filler or filler == "\x08":
                 return ""
             else:
-                return "[pr]{}[/pr]".format(filler)
+                return "[pr]{0}[/pr]".format(filler)
 
         return re.sub(self.pre_regex, replace_it, html)
 

--- a/tests/test_parse_ansi_to_html.py
+++ b/tests/test_parse_ansi_to_html.py
@@ -34,7 +34,7 @@ def unescaped_html_content(html):
                 ]
 
     matcher = "|".join([key for key in regex_map])
-    res = re.sub(r"{}".format(matcher), translate, html)
+    res = re.sub(r"{0}".format(matcher), translate, html)
     import ipdb; ipdb.set_trace()
 
 def test_reader():


### PR DESCRIPTION
As we'd talked about, I made tweaks for the string `format` and `webbrowser` situations.  Subprocess's `check_output` wasn't supported either so I used `Popen`/`read`.  The `script` command wasn't set to flush with input and was printing timing info to my command line so I've updated that as well.  Hope that's ok!
